### PR TITLE
feat: optimized performance for http still image sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ _mdwriter.cson
 **/.peerjsrc
 **/ambianic_edge.egg-info/
 ambianic-debug2.sh
+config.yaml.local

--- a/src/ambianic/pipeline/avsource/av_element.py
+++ b/src/ambianic/pipeline/avsource/av_element.py
@@ -114,7 +114,7 @@ class AVSourceElement(PipeElement):
                     log.debug('Completed one time http image fetch from URL: %r',
                             url)
                     break
-            except:
+            except Exception:
                 log.exception("""
                     Failed to fetch image from pipeline source. 
                     URL: %r

--- a/src/ambianic/pipeline/avsource/gst_process.py
+++ b/src/ambianic/pipeline/avsource/gst_process.py
@@ -138,7 +138,7 @@ class GstService:
             self._on_bus_message_error(message)
         else:
             # pass
-            log.debug('GST: Unexpected bus message: type: %r, details: %r',
+            log.debug('GST: Ignoring bus message: type: %r, details: %r',
                       message.type.get_name(message.type), message)
         return True
 

--- a/src/ambianic/util.py
+++ b/src/ambianic/util.py
@@ -1,5 +1,6 @@
 """Service classes for OS interaction and multithreading."""
 import threading
+from threading import Thread, current_thread, Event
 import logging
 import traceback
 import time
@@ -48,10 +49,10 @@ class ManagedService:
         """
 
 
-class ThreadedJob(threading.Thread, ManagedService):
+class ThreadedJob(Thread, ManagedService):
     """A job that runs in its own python thread.
 
-    Jobs managed by Threaded Job must have a start(), stop() method.
+    Jobs managed by Threaded Job must implement all ManagedService methods.
     """
 
     # Reminder: even though multiple processes can work well for pipelines,
@@ -68,14 +69,14 @@ class ThreadedJob(threading.Thread, ManagedService):
         job : ManagedService
             The underlying service wrapped in this thread.
         """
-        threading.Thread.__init__(self, daemon=True)
+        Thread.__init__(self, daemon=True)
         assert isinstance(job, ManagedService)
         self.job = job
         # The shutdown_flag is a threading.Event object that
         # indicates whether the thread should be terminated.
         # self.shutdown_flag = threading.Event()
         # ... Other thread setup code here ...
-        self._stop_requested = threading.Event()
+        self._stop_requested = Event()
 
     def run(self):
         log.info('Thread #%s started with job: %s',

--- a/tests/pipeline/avsource/test_avsource_http.py
+++ b/tests/pipeline/avsource/test_avsource_http.py
@@ -228,3 +228,4 @@ def test_exception_on_new_sample():
     assert y0 > 0 and y0 < y1
     t.join(timeout=3)
     assert not t.is_alive()
+    

--- a/tests/pipeline/avsource/test_avsource_http.py
+++ b/tests/pipeline/avsource/test_avsource_http.py
@@ -1,0 +1,230 @@
+"""Test audio/video source pipeline element."""
+import pytest
+from ambianic.pipeline.avsource.av_element \
+    import AVSourceElement, MIN_HEALING_INTERVAL
+import threading
+import os
+import pathlib
+import time
+from ambianic.pipeline import PipeElement
+from ambianic.pipeline.ai.object_detect import ObjectDetector
+import logging
+
+log = logging.getLogger()
+log.setLevel(logging.DEBUG)
+
+
+def _object_detect_config():
+    _dir = os.path.dirname(os.path.abspath(__file__))
+    _good_tflite_model = os.path.join(
+        _dir,
+        '../ai/mobilenet_ssd_v2_coco_quant_postprocess.tflite'
+        )
+    _good_edgetpu_model = os.path.join(
+        _dir,
+        '../ai/mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite'
+        )
+    _good_labels = os.path.join(_dir, '../ai/coco_labels.txt')
+    config = {
+        'model': {
+            'tflite': _good_tflite_model,
+            'edgetpu': _good_edgetpu_model,
+            },
+        'labels': _good_labels,
+        'top_k': 3,
+        'confidence_threshold': 0.8,
+    }
+    return config
+
+
+class _TestAVSourceElement(AVSourceElement):
+
+    def __init__(self, **source_conf):
+        super().__init__(**source_conf)
+        self._run_gst_service_called = False
+        self._stop_gst_service_called = False
+
+    def _run_http_fetch(self):
+        self._run_http_fetch_called = True
+
+class _OutPipeElement(PipeElement):
+
+    def __init__(self, sample_callback=None):
+        super().__init__()
+        assert sample_callback
+        self._sample_callback = sample_callback
+
+    def receive_next_sample(self, **sample):
+        self._sample_callback(**sample)
+
+
+def test_http_still_image_input_detect_person_exit():
+    """Process a single jpg image. Detect a person and exit pipeline."""
+    source_uri = 'https://raw.githubusercontent.com/ambianic/ambianic-edge/master/tests/pipeline/ai/person.jpg'
+    avsource = AVSourceElement(uri=source_uri, type='image', live=False)
+    object_config = _object_detect_config()
+    detection_received = threading.Event()
+    sample_image = None
+    detections = None
+
+    def sample_callback(image=None, inference_result=None, **kwargs):
+        nonlocal sample_image
+        nonlocal detection_received
+        sample_image = image
+        nonlocal detections
+        detections = inference_result
+        print('detections: {det}'.format(det=detections))
+        print('len(detections): {len}'.format(len=len(detections)))
+        if detections:
+            label, confidence, _ = detections[0]
+            if label == 'person' and confidence > 0.9:
+                # skip video image samples until we reach a person detection
+                # with high level of confidence
+                detection_received.set()
+
+    object_detector = ObjectDetector(**object_config)
+    avsource.connect_to_next_element(object_detector)
+    output = _OutPipeElement(sample_callback=sample_callback)
+    object_detector.connect_to_next_element(output)
+    t = threading.Thread(
+        name="Test AVSourceElement",
+        target=avsource.start, daemon=True
+        )
+    t.start()
+    detection_received.wait(timeout=10)
+    assert sample_image
+    assert sample_image.size[0] == 1280
+    assert sample_image.size[1] == 720
+    assert detections
+    assert len(detections) == 1
+    label, confidence, (x0, y0, x1, y1) = detections[0]
+    assert label == 'person'
+    assert confidence > 0.9
+    assert x0 > 0 and x0 < x1
+    assert y0 > 0 and y0 < y1
+    t.join(timeout=10)
+    assert not t.is_alive()
+
+
+def test_http_still_image_input_detect_person_exit_stop_signal():
+    """Proces a single jpg image. Detect a person. Exit via stop signal."""
+    source_uri = 'https://raw.githubusercontent.com/ambianic/ambianic-edge/master/tests/pipeline/ai/person.jpg'
+    avsource = AVSourceElement(uri=source_uri, type='image', live=True)
+    object_config = _object_detect_config()
+    detection_received = threading.Event()
+    sample_image = None
+    detections = None
+
+    def sample_callback(image=None, inference_result=None, **kwargs):
+        nonlocal sample_image
+        nonlocal detection_received
+        sample_image = image
+        nonlocal detections
+        detections = inference_result
+        print('detections: {det}'.format(det=detections))
+        print('len(detections): {len}'.format(len=len(detections)))
+        if detections:
+            label, confidence, _ = detections[0]
+            if label == 'person' and confidence > 0.9:
+                # skip video image samples until we reach a person detection
+                # with high level of confidence
+                detection_received.set()
+    object_detector = ObjectDetector(**object_config)
+    avsource.connect_to_next_element(object_detector)
+    output = _OutPipeElement(sample_callback=sample_callback)
+    object_detector.connect_to_next_element(output)
+    t = threading.Thread(
+        name="Test AVSourceElement",
+        target=avsource.start, daemon=True
+        )
+    t.start()
+    detection_received.wait(timeout=10)
+    assert sample_image
+    assert sample_image.size[0] == 1280
+    assert sample_image.size[1] == 720
+    assert detections
+    assert len(detections) == 1
+    label, confidence, (x0, y0, x1, y1) = detections[0]
+    assert label == 'person'
+    assert confidence > 0.9
+    assert x0 > 0 and x0 < x1
+    assert y0 > 0 and y0 < y1
+    avsource.stop()
+    t.join(timeout=10)
+    assert not t.is_alive()
+
+class _TestAVSourceElement2(AVSourceElement):
+
+    def __init__(self, **source_conf):
+        super().__init__(**source_conf)
+        self._bad_sample_processed_re = False
+        self._bad_sample_processed_ae = False
+
+    def _get_sample_queue(self):
+        q = super()._get_sample_queue()
+        # put a fake bad sample on the queue to test exception handling
+        q.put('A bad sample to test RuntimeError.')
+        q.put('Another bad sample to test AssertionError.')
+        return q
+
+    def _on_new_sample(self, sample=None):
+        if not self._bad_sample_processed_re:
+            # through a RuntimeError once then proceed as normal
+            # the pipe element should log the exception but keep running
+            print('RuntimeError during processing.')
+            self._bad_sample_processed_re = True
+            raise RuntimeError('Something went wrong during processing.')
+        if not self._bad_sample_processed_ae:
+            # through an AssertionError once then proceed as normal
+            # the pipe element should log the exception but keep running
+            print('AssertionError during processing.')
+            self._bad_sample_processed_ae = True
+            raise AssertionError('Something went wrong during processing.')
+        super()._on_new_sample(sample)
+
+
+def test_exception_on_new_sample():
+    """Exception from _on_new_sample() should not break the pipe loop."""
+    source_uri = 'https://raw.githubusercontent.com/ambianic/ambianic-edge/master/tests/pipeline/ai/person.jpg'
+    avsource = _TestAVSourceElement2(uri=source_uri, type='image', live=False)
+    object_config = _object_detect_config()
+    detection_received = threading.Event()
+    sample_image = None
+    detections = None
+
+    def sample_callback(image=None, inference_result=None, **kwargs):
+        nonlocal sample_image
+        nonlocal detection_received
+        sample_image = image
+        nonlocal detections
+        detections = inference_result
+        print('detections: {det}'.format(det=detections))
+        print('len(detections): {len}'.format(len=len(detections)))
+        if detections:
+            label, confidence, _ = detections[0]
+            if label == 'person' and confidence > 0.9:
+                # skip video image samples until we reach a person detection
+                # with high level of confidence
+                detection_received.set()
+    object_detector = ObjectDetector(**object_config)
+    avsource.connect_to_next_element(object_detector)
+    output = _OutPipeElement(sample_callback=sample_callback)
+    object_detector.connect_to_next_element(output)
+    t = threading.Thread(
+        name="Test AVSourceElement",
+        target=avsource.start, daemon=True
+        )
+    t.start()
+    detection_received.wait(timeout=10)
+    assert sample_image
+    assert sample_image.size[0] == 1280
+    assert sample_image.size[1] == 720
+    assert detections
+    assert len(detections) == 1
+    label, confidence, (x0, y0, x1, y1) = detections[0]
+    assert label == 'person'
+    assert confidence > 0.9
+    assert x0 > 0 and x0 < x1
+    assert y0 > 0 and y0 < y1
+    t.join(timeout=3)
+    assert not t.is_alive()

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -13,7 +13,7 @@ echo "Script location: ${BASEDIR}"
 # where codecov can find the generated reports
 cd $BASEDIR/../
 echo PWD=$PWD
-python3 -m pytest --cov=ambianic --cov-report=xml tests/
+python3 -m pytest --cov=ambianic --cov-report=xml --cov-report=term tests/
 # pytest --cov-report=xml --cov=ambianic tests
 # codecov
 # pylint --errors-only src/ambianic


### PR DESCRIPTION
When sources are marked as still images via
type: image
source: http***

AVSourceElement use the lightweight python requests library to fetch the next image
snapshot from the camera instead of using gstreamer.
That saves resources from creating separate process for gstreamer with its own threads and overhead.
Gsteramer is still used for all other media sources.