### PR TITLE
feat: include rotated event logs in the timeline events

### DIFF
--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -1,0 +1,25 @@
+import pytest
+import os
+
+from ambianic.webapp.server.samples import get_timeline
+
+# logs size is 24 records long, splitted in 3 files of 8 events each
+
+
+def test_get_timeline_overflow():
+    data_dir = os.path.join(os.path.dirname(
+        os.path.abspath(__file__)), "./timeline"
+    )
+    res = get_timeline(before_datetime=None, page=7, data_dir=data_dir)
+    assert len(res) == 0
+
+
+def test_get_timelines():
+    data_dir = os.path.join(os.path.dirname(
+        os.path.abspath(__file__)), "./timeline"
+    )
+    for page in range(1, 6):
+        res = get_timeline(before_datetime=None, page=page, data_dir=data_dir)
+        # print("page", page, "list", list(map(lambda r: r["id"], res)), "\n---")
+        assert len(res) > 0
+        assert res[0]["id"] == "page%d" % page

--- a/tests/timeline/timeline-event-log.yaml.0
+++ b/tests/timeline/timeline-event-log.yaml.0
@@ -1,0 +1,205 @@
+
+
+# page2
+- args:
+    datetime: '2020-05-10T19:05:45.577145'
+    id: page2
+    image_file_name: 20200510-190545.577145-image.jpg
+    inference_meta:
+      display: Object Detection
+    inference_result:
+    - box:
+        xmax: 0.7228575944900513
+        xmin: 0.3868940770626068
+        ymax: 1.0
+        ymin: 0.12535724414170846
+      confidence: 0.9921875
+      label: person
+    json_file_name: 20200510-190545.577145-inference.json
+    rel_dir: detections/20200510-190544.936209
+    thumbnail_file_name: 20200510-190545.577145-thumbnail.jpg
+  created: 1589137545.6190686
+  id: page2
+  message: Detection Event
+  priority: INFO
+  source_code:
+    funcName: _save_sample
+    lineno: 117
+    pathname: /workspace/src/ambianic/pipeline/store.py
+- args:
+    datetime: '2020-05-10T19:05:45.577145'
+    id: page2
+    image_file_name: 20200510-190545.577145-image.jpg
+    inference_meta:
+      display: Object Detection
+    inference_result:
+    - box:
+        xmax: 0.7228575944900513
+        xmin: 0.3868940770626068
+        ymax: 1.0
+        ymin: 0.12535724414170846
+      confidence: 0.9921875
+      label: person
+    json_file_name: 20200510-190545.577145-inference.json
+    rel_dir: detections/20200510-190544.936209
+    thumbnail_file_name: 20200510-190545.577145-thumbnail.jpg
+  created: 1589137545.6190686
+  id: page2
+  message: Detection Event
+  priority: INFO
+  source_code:
+    funcName: _save_sample
+    lineno: 117
+    pathname: /workspace/src/ambianic/pipeline/store.py
+- args:
+    datetime: '2020-05-10T19:05:45.577145'
+    id: page2
+    image_file_name: 20200510-190545.577145-image.jpg
+    inference_meta:
+      display: Object Detection
+    inference_result:
+    - box:
+        xmax: 0.7228575944900513
+        xmin: 0.3868940770626068
+        ymax: 1.0
+        ymin: 0.12535724414170846
+      confidence: 0.9921875
+      label: person
+    json_file_name: 20200510-190545.577145-inference.json
+    rel_dir: detections/20200510-190544.936209
+    thumbnail_file_name: 20200510-190545.577145-thumbnail.jpg
+  created: 1589137545.6190686
+  id: page2
+  message: Detection Event
+  priority: INFO
+  source_code:
+    funcName: _save_sample
+    lineno: 117
+    pathname: /workspace/src/ambianic/pipeline/store.py
+
+# page1
+- args:
+    datetime: '2020-05-10T19:05:45.577145'
+    id: page1
+    image_file_name: 20200510-190545.577145-image.jpg
+    inference_meta:
+      display: Object Detection
+    inference_result:
+    - box:
+        xmax: 0.7228575944900513
+        xmin: 0.3868940770626068
+        ymax: 1.0
+        ymin: 0.12535724414170846
+      confidence: 0.9921875
+      label: person
+    json_file_name: 20200510-190545.577145-inference.json
+    rel_dir: detections/20200510-190544.936209
+    thumbnail_file_name: 20200510-190545.577145-thumbnail.jpg
+  created: 1589137545.6190686
+  id: page1
+  message: Detection Event
+  priority: INFO
+  source_code:
+    funcName: _save_sample
+    lineno: 117
+    pathname: /workspace/src/ambianic/pipeline/store.py
+- args:
+    datetime: '2020-05-10T19:05:45.577145'
+    id: page1
+    image_file_name: 20200510-190545.577145-image.jpg
+    inference_meta:
+      display: Object Detection
+    inference_result:
+    - box:
+        xmax: 0.7228575944900513
+        xmin: 0.3868940770626068
+        ymax: 1.0
+        ymin: 0.12535724414170846
+      confidence: 0.9921875
+      label: person
+    json_file_name: 20200510-190545.577145-inference.json
+    rel_dir: detections/20200510-190544.936209
+    thumbnail_file_name: 20200510-190545.577145-thumbnail.jpg
+  created: 1589137545.6190686
+  id: page1
+  message: Detection Event
+  priority: INFO
+  source_code:
+    funcName: _save_sample
+    lineno: 117
+    pathname: /workspace/src/ambianic/pipeline/store.py
+- args:
+    datetime: '2020-05-10T19:05:45.577145'
+    id: page1
+    image_file_name: 20200510-190545.577145-image.jpg
+    inference_meta:
+      display: Object Detection
+    inference_result:
+    - box:
+        xmax: 0.7228575944900513
+        xmin: 0.3868940770626068
+        ymax: 1.0
+        ymin: 0.12535724414170846
+      confidence: 0.9921875
+      label: person
+    json_file_name: 20200510-190545.577145-inference.json
+    rel_dir: detections/20200510-190544.936209
+    thumbnail_file_name: 20200510-190545.577145-thumbnail.jpg
+  created: 1589137545.6190686
+  id: page1
+  message: Detection Event
+  priority: INFO
+  source_code:
+    funcName: _save_sample
+    lineno: 117
+    pathname: /workspace/src/ambianic/pipeline/store.py
+- args:
+    datetime: '2020-05-10T19:05:45.577145'
+    id: page1
+    image_file_name: 20200510-190545.577145-image.jpg
+    inference_meta:
+      display: Object Detection
+    inference_result:
+    - box:
+        xmax: 0.7228575944900513
+        xmin: 0.3868940770626068
+        ymax: 1.0
+        ymin: 0.12535724414170846
+      confidence: 0.9921875
+      label: person
+    json_file_name: 20200510-190545.577145-inference.json
+    rel_dir: detections/20200510-190544.936209
+    thumbnail_file_name: 20200510-190545.577145-thumbnail.jpg
+  created: 1589137545.6190686
+  id: page1
+  message: Detection Event
+  priority: INFO
+  source_code:
+    funcName: _save_sample
+    lineno: 117
+    pathname: /workspace/src/ambianic/pipeline/store.py
+- args:
+    datetime: '2020-05-10T19:05:45.577145'
+    id: page1
+    image_file_name: 20200510-190545.577145-image.jpg
+    inference_meta:
+      display: Object Detection
+    inference_result:
+    - box:
+        xmax: 0.7228575944900513
+        xmin: 0.3868940770626068
+        ymax: 1.0
+        ymin: 0.12535724414170846
+      confidence: 0.9921875
+      label: person
+    json_file_name: 20200510-190545.577145-inference.json
+    rel_dir: detections/20200510-190544.936209
+    thumbnail_file_name: 20200510-190545.577145-thumbnail.jpg
+  created: 1589137545.6190686
+  id: page1
+  message: Detection Event
+  priority: INFO
+  source_code:
+    funcName: _save_sample
+    lineno: 117
+    pathname: /workspace/src/ambianic/pipeline/store.py

--- a/tests/timeline/timeline-event-log.yaml.1
+++ b/tests/timeline/timeline-event-log.yaml.1
@@ -1,0 +1,208 @@
+
+# page4
+- args:
+    datetime: '2020-05-05T19:05:45.577145'
+    id: page4
+    image_file_name: 20200510-190545.577145-image.jpg
+    inference_meta:
+      display: Object Detection
+    inference_result:
+    - box:
+        xmax: 0.7228575944900513
+        xmin: 0.3868940770626068
+        ymax: 1.0
+        ymin: 0.12535724414170846
+      confidence: 0.9921875
+      label: person
+    json_file_name: 20200510-190545.577145-inference.json
+    rel_dir: detections/20200510-190544.936209
+    thumbnail_file_name: 20200510-190545.577145-thumbnail.jpg
+  created: 1589137545.6190686
+  id: page4
+  message: Detection Event
+  priority: INFO
+  source_code:
+    funcName: _save_sample
+    lineno: 117
+    pathname: /workspace/src/ambianic/pipeline/store.py
+
+
+# page3
+- args:
+    datetime: '2020-05-05T19:05:45.577145'
+    id: page3
+    image_file_name: 20200510-190545.577145-image.jpg
+    inference_meta:
+      display: Object Detection
+    inference_result:
+    - box:
+        xmax: 0.7228575944900513
+        xmin: 0.3868940770626068
+        ymax: 1.0
+        ymin: 0.12535724414170846
+      confidence: 0.9921875
+      label: person
+    json_file_name: 20200510-190545.577145-inference.json
+    rel_dir: detections/20200510-190544.936209
+    thumbnail_file_name: 20200510-190545.577145-thumbnail.jpg
+  created: 1589137545.6190686
+  id: page3
+  message: Detection Event
+  priority: INFO
+  source_code:
+    funcName: _save_sample
+    lineno: 117
+    pathname: /workspace/src/ambianic/pipeline/store.py
+- args:
+    datetime: '2020-05-05T19:05:45.577145'
+    id: page3
+    image_file_name: 20200510-190545.577145-image.jpg
+    inference_meta:
+      display: Object Detection
+    inference_result:
+    - box:
+        xmax: 0.7228575944900513
+        xmin: 0.3868940770626068
+        ymax: 1.0
+        ymin: 0.12535724414170846
+      confidence: 0.9921875
+      label: person
+    json_file_name: 20200510-190545.577145-inference.json
+    rel_dir: detections/20200510-190544.936209
+    thumbnail_file_name: 20200510-190545.577145-thumbnail.jpg
+  created: 1589137545.6190686
+  id: page3
+  message: Detection Event
+  priority: INFO
+  source_code:
+    funcName: _save_sample
+    lineno: 117
+    pathname: /workspace/src/ambianic/pipeline/store.py
+- args:
+    datetime: '2020-05-05T19:05:45.577145'
+    id: page3
+    image_file_name: 20200510-190545.577145-image.jpg
+    inference_meta:
+      display: Object Detection
+    inference_result:
+    - box:
+        xmax: 0.7228575944900513
+        xmin: 0.3868940770626068
+        ymax: 1.0
+        ymin: 0.12535724414170846
+      confidence: 0.9921875
+      label: person
+    json_file_name: 20200510-190545.577145-inference.json
+    rel_dir: detections/20200510-190544.936209
+    thumbnail_file_name: 20200510-190545.577145-thumbnail.jpg
+  created: 1589137545.6190686
+  id: page3
+  message: Detection Event
+  priority: INFO
+  source_code:
+    funcName: _save_sample
+    lineno: 117
+    pathname: /workspace/src/ambianic/pipeline/store.py
+- args:
+    datetime: '2020-05-05T19:05:45.577145'
+    id: page3
+    image_file_name: 20200510-190545.577145-image.jpg
+    inference_meta:
+      display: Object Detection
+    inference_result:
+    - box:
+        xmax: 0.7228575944900513
+        xmin: 0.3868940770626068
+        ymax: 1.0
+        ymin: 0.12535724414170846
+      confidence: 0.9921875
+      label: person
+    json_file_name: 20200510-190545.577145-inference.json
+    rel_dir: detections/20200510-190544.936209
+    thumbnail_file_name: 20200510-190545.577145-thumbnail.jpg
+  created: 1589137545.6190686
+  id: page3
+  message: Detection Event
+  priority: INFO
+  source_code:
+    funcName: _save_sample
+    lineno: 117
+    pathname: /workspace/src/ambianic/pipeline/store.py
+- args:
+    datetime: '2020-05-05T19:05:45.577145'
+    id: page3
+    image_file_name: 20200510-190545.577145-image.jpg
+    inference_meta:
+      display: Object Detection
+    inference_result:
+    - box:
+        xmax: 0.7228575944900513
+        xmin: 0.3868940770626068
+        ymax: 1.0
+        ymin: 0.12535724414170846
+      confidence: 0.9921875
+      label: person
+    json_file_name: 20200510-190545.577145-inference.json
+    rel_dir: detections/20200510-190544.936209
+    thumbnail_file_name: 20200510-190545.577145-thumbnail.jpg
+  created: 1589137545.6190686
+  id: page3
+  message: Detection Event
+  priority: INFO
+  source_code:
+    funcName: _save_sample
+    lineno: 117
+    pathname: /workspace/src/ambianic/pipeline/store.py
+
+
+# page2
+- args:
+    datetime: '2020-05-05T19:05:45.577145'
+    id: page2
+    image_file_name: 20200510-190545.577145-image.jpg
+    inference_meta:
+      display: Object Detection
+    inference_result:
+    - box:
+        xmax: 0.7228575944900513
+        xmin: 0.3868940770626068
+        ymax: 1.0
+        ymin: 0.12535724414170846
+      confidence: 0.9921875
+      label: person
+    json_file_name: 20200510-190545.577145-inference.json
+    rel_dir: detections/20200510-190544.936209
+    thumbnail_file_name: 20200510-190545.577145-thumbnail.jpg
+  created: 1589137545.6190686
+  id: page2
+  message: Detection Event
+  priority: INFO
+  source_code:
+    funcName: _save_sample
+    lineno: 117
+    pathname: /workspace/src/ambianic/pipeline/store.py
+- args:
+    datetime: '2020-05-05T19:05:45.577145'
+    id: page2
+    image_file_name: 20200510-190545.577145-image.jpg
+    inference_meta:
+      display: Object Detection
+    inference_result:
+    - box:
+        xmax: 0.7228575944900513
+        xmin: 0.3868940770626068
+        ymax: 1.0
+        ymin: 0.12535724414170846
+      confidence: 0.9921875
+      label: person
+    json_file_name: 20200510-190545.577145-inference.json
+    rel_dir: detections/20200510-190544.936209
+    thumbnail_file_name: 20200510-190545.577145-thumbnail.jpg
+  created: 1589137545.6190686
+  id: page2
+  message: Detection Event
+  priority: INFO
+  source_code:
+    funcName: _save_sample
+    lineno: 117
+    pathname: /workspace/src/ambianic/pipeline/store.py

--- a/tests/timeline/timeline-event-log.yaml.2
+++ b/tests/timeline/timeline-event-log.yaml.2
@@ -1,0 +1,205 @@
+
+# page5
+- args:
+    datetime: '2020-05-05T19:05:45.577145'
+    id: page5
+    image_file_name: 20200510-190545.577145-image.jpg
+    inference_meta:
+      display: Object Detection
+    inference_result:
+    - box:
+        xmax: 0.7228575944900513
+        xmin: 0.3868940770626068
+        ymax: 1.0
+        ymin: 0.12535724414170846
+      confidence: 0.9921875
+      label: person
+    json_file_name: 20200510-190545.577145-inference.json
+    rel_dir: detections/20200510-190544.936209
+    thumbnail_file_name: 20200510-190545.577145-thumbnail.jpg
+  created: 1589137545.6190686
+  id: page5
+  message: Detection Event
+  priority: INFO
+  source_code:
+    funcName: _save_sample
+    lineno: 117
+    pathname: /workspace/src/ambianic/pipeline/store.py
+- args:
+    datetime: '2020-05-05T19:05:45.577145'
+    id: page5
+    image_file_name: 20200510-190545.577145-image.jpg
+    inference_meta:
+      display: Object Detection
+    inference_result:
+    - box:
+        xmax: 0.7228575944900513
+        xmin: 0.3868940770626068
+        ymax: 1.0
+        ymin: 0.12535724414170846
+      confidence: 0.9921875
+      label: person
+    json_file_name: 20200510-190545.577145-inference.json
+    rel_dir: detections/20200510-190544.936209
+    thumbnail_file_name: 20200510-190545.577145-thumbnail.jpg
+  created: 1589137545.6190686
+  id: page5
+  message: Detection Event
+  priority: INFO
+  source_code:
+    funcName: _save_sample
+    lineno: 117
+    pathname: /workspace/src/ambianic/pipeline/store.py
+- args:
+    datetime: '2020-05-05T19:05:45.577145'
+    id: page5
+    image_file_name: 20200510-190545.577145-image.jpg
+    inference_meta:
+      display: Object Detection
+    inference_result:
+    - box:
+        xmax: 0.7228575944900513
+        xmin: 0.3868940770626068
+        ymax: 1.0
+        ymin: 0.12535724414170846
+      confidence: 0.9921875
+      label: person
+    json_file_name: 20200510-190545.577145-inference.json
+    rel_dir: detections/20200510-190544.936209
+    thumbnail_file_name: 20200510-190545.577145-thumbnail.jpg
+  created: 1589137545.6190686
+  id: page5
+  message: Detection Event
+  priority: INFO
+  source_code:
+    funcName: _save_sample
+    lineno: 117
+    pathname: /workspace/src/ambianic/pipeline/store.py
+- args:
+    datetime: '2020-05-05T19:05:45.577145'
+    id: page5
+    image_file_name: 20200510-190545.577145-image.jpg
+    inference_meta:
+      display: Object Detection
+    inference_result:
+    - box:
+        xmax: 0.7228575944900513
+        xmin: 0.3868940770626068
+        ymax: 1.0
+        ymin: 0.12535724414170846
+      confidence: 0.9921875
+      label: person
+    json_file_name: 20200510-190545.577145-inference.json
+    rel_dir: detections/20200510-190544.936209
+    thumbnail_file_name: 20200510-190545.577145-thumbnail.jpg
+  created: 1589137545.6190686
+  id: page5
+  message: Detection Event
+  priority: INFO
+  source_code:
+    funcName: _save_sample
+    lineno: 117
+    pathname: /workspace/src/ambianic/pipeline/store.py
+
+
+# page4
+- args:
+    datetime: '2020-05-05T19:05:45.577145'
+    id: page4
+    image_file_name: 20200510-190545.577145-image.jpg
+    inference_meta:
+      display: Object Detection
+    inference_result:
+    - box:
+        xmax: 0.7228575944900513
+        xmin: 0.3868940770626068
+        ymax: 1.0
+        ymin: 0.12535724414170846
+      confidence: 0.9921875
+      label: person
+    json_file_name: 20200510-190545.577145-inference.json
+    rel_dir: detections/20200510-190544.936209
+    thumbnail_file_name: 20200510-190545.577145-thumbnail.jpg
+  created: 1589137545.6190686
+  id: page4
+  message: Detection Event
+  priority: INFO
+  source_code:
+    funcName: _save_sample
+    lineno: 117
+    pathname: /workspace/src/ambianic/pipeline/store.py
+- args:
+    datetime: '2020-05-05T19:05:45.577145'
+    id: page4
+    image_file_name: 20200510-190545.577145-image.jpg
+    inference_meta:
+      display: Object Detection
+    inference_result:
+    - box:
+        xmax: 0.7228575944900513
+        xmin: 0.3868940770626068
+        ymax: 1.0
+        ymin: 0.12535724414170846
+      confidence: 0.9921875
+      label: person
+    json_file_name: 20200510-190545.577145-inference.json
+    rel_dir: detections/20200510-190544.936209
+    thumbnail_file_name: 20200510-190545.577145-thumbnail.jpg
+  created: 1589137545.6190686
+  id: page4
+  message: Detection Event
+  priority: INFO
+  source_code:
+    funcName: _save_sample
+    lineno: 117
+    pathname: /workspace/src/ambianic/pipeline/store.py
+- args:
+    datetime: '2020-05-05T19:05:45.577145'
+    id: page4
+    image_file_name: 20200510-190545.577145-image.jpg
+    inference_meta:
+      display: Object Detection
+    inference_result:
+    - box:
+        xmax: 0.7228575944900513
+        xmin: 0.3868940770626068
+        ymax: 1.0
+        ymin: 0.12535724414170846
+      confidence: 0.9921875
+      label: person
+    json_file_name: 20200510-190545.577145-inference.json
+    rel_dir: detections/20200510-190544.936209
+    thumbnail_file_name: 20200510-190545.577145-thumbnail.jpg
+  created: 1589137545.6190686
+  id: page4
+  message: Detection Event
+  priority: INFO
+  source_code:
+    funcName: _save_sample
+    lineno: 117
+    pathname: /workspace/src/ambianic/pipeline/store.py
+- args:
+    datetime: '2020-05-05T19:05:45.577145'
+    id: page4
+    image_file_name: 20200510-190545.577145-image.jpg
+    inference_meta:
+      display: Object Detection
+    inference_result:
+    - box:
+        xmax: 0.7228575944900513
+        xmin: 0.3868940770626068
+        ymax: 1.0
+        ymin: 0.12535724414170846
+      confidence: 0.9921875
+      label: person
+    json_file_name: 20200510-190545.577145-inference.json
+    rel_dir: detections/20200510-190544.936209
+    thumbnail_file_name: 20200510-190545.577145-thumbnail.jpg
+  created: 1589137545.6190686
+  id: page4
+  message: Detection Event
+  priority: INFO
+  source_code:
+    funcName: _save_sample
+    lineno: 117
+    pathname: /workspace/src/ambianic/pipeline/store.py


### PR DESCRIPTION
The implementation load the list of available logs and create a list of events order old-first. It may not perform well on a constrained device with a large number of files.

Refs #187