### PR TITLE
feat: use concurrent log rotation implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ _mdwriter.cson
 **/ambianic_edge.egg-info/
 ambianic-debug2.sh
 config.yaml.local
+/.ropeproject

--- a/src/ambianic/pipeline/timeline.py
+++ b/src/ambianic/pipeline/timeline.py
@@ -1,5 +1,6 @@
 """Pipeline event timeline read/write/search functions."""
 
+from concurrent_log_handler import ConcurrentRotatingFileHandler
 import logging
 import yaml
 import uuid
@@ -145,12 +146,13 @@ def configure_timeline(config: dict = None):
     event_log = logging.getLogger(TIMELINE_EVENT_LOGGER_NAME)
     event_log.setLevel(logging.INFO)
     # Use rotating files as log message handler
-    handler = logging.handlers.RotatingFileHandler(
-                  log_filename,
-                  # each event file will keep up to 100K data
-                  maxBytes=100*1024,
-                  # 100 backup files will be kept. Older will be erased.
-                  backupCount=100)
+    handler = ConcurrentRotatingFileHandler(
+        log_filename,
+        # each event file will keep up to 100K data
+        maxBytes=100*1024,
+        # 100 backup files will be kept. Older will be erased.
+        backupCount=100
+    )
     fmt = PipelineEventFormatter()
     handler.setFormatter(fmt)
     # remove any other handlers that may be assigned previously

--- a/src/setup.cfg
+++ b/src/setup.cfg
@@ -8,7 +8,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://ambianic.ai
 license = Apache Software License 2.0
-classifiers = 
+classifiers =
 	Development Status :: Beta
 	Programming Language :: Python :: 3
 	OSI Approved :: Apache Software License
@@ -21,5 +21,5 @@ classifiers =
 [options]
 packages = find:
 python_requires = >=3.6
-install_requires = 
-
+install_requires =
+	concurrent-log-handler


### PR DESCRIPTION
Uses [concurrent-log-handler](https://github.com/Preston-Landers/concurrent-log-handler) as drop-in replacement for native log rotation with better support for multithreading

Refs #170 