### PR TITLE
Logging and conditional testing for configuration processing

### DIFF
--- a/src/ambianic/__init__.py
+++ b/src/ambianic/__init__.py
@@ -2,7 +2,7 @@
 import os
 from ambianic.config_mgm import ConfigurationManager
 
-DEFAULT_WORK_DIR = '/workspace'
+DEFAULT_WORK_DIR = '/data/ambianic'
 
 config_manager = ConfigurationManager()
 server_instance = None

--- a/src/ambianic/__init__.py
+++ b/src/ambianic/__init__.py
@@ -2,7 +2,7 @@
 import os
 from ambianic.config_mgm import ConfigurationManager
 
-DEFAULT_WORK_DIR = '/data/ambianic'
+DEFAULT_WORK_DIR = '/workspace'
 
 config_manager = ConfigurationManager()
 server_instance = None

--- a/src/ambianic/config_mgm/configuration_manager.py
+++ b/src/ambianic/config_mgm/configuration_manager.py
@@ -115,7 +115,7 @@ class ConfigurationManager:
                 all_config = secrets_config + "\n" + base_config
             config = yaml.safe_load(all_config)
 
-            log.debug('loaded config from %r: %r',
+            log.info('loaded config from %r: %r',
                       self.CONFIG_FILE, config)
 
             return self.set(config)

--- a/src/ambianic/pipeline/interpreter.py
+++ b/src/ambianic/pipeline/interpreter.py
@@ -258,24 +258,30 @@ class Pipeline(ManagedService):
 
             # copy the dictionary to not modify the configuration reference
             if isinstance(_element_config, (config_mgm.ConfigList, config_mgm.ConfigDict)):
+                log.debug('Copying values: %s',element_def)
                 element_def = _element_config.to_values()
             else:
                 # if it is a dict (eg. in tests)
+                log.debug('Deep copying values: %s',element_def)
                 element_def = copy.deepcopy(_element_config)
 
             log.info('Pipeline %s loading next element: %s', self.name, element_def)
 
             is_valid = self.parse_source_config(element_def)
             if not is_valid:
-                log.warning('FAILED: Pipeline: %s; source: %s',self.name, element_def)
+                log.warning('Not source: Pipeline: %s; elementL %s',self.name, element_def)
                 self._pipe_elements = []
                 break
+            else:
+                log.debug('Valid source %s',element_def)
 
             is_valid = self.parse_ai_model_config(element_def)
             if not is_valid:
-                log.warning('FAILED: Pipeline: %s; ai_model: %s',self.name, element_def)
+                log.warning('Not ai_model: Pipeline: %s; elementL %s',self.name, element_def)
                 self._pipe_elements = []
                 break
+            else:
+                log.debug('Valid ai_model %s',element_def)
 
             log.debug('CHECKPOINT: Pipeline: %s; element: %s',self.name,element_def)
 
@@ -283,13 +289,19 @@ class Pipeline(ManagedService):
             assert element_name
             element_config = element_def[element_name]
 
+            log.debug('CHECKPOINT: Pipeline: %s; element config: %s',self.name,element_config)
+
             # if dealing with a static reference, pass the whole object
             # eg. { [source]: [source-name] }
             if isinstance(element_config, str):
-                log.debug('element is string')
+                log.debug('Element config is string')
                 element_config = {element_name: element_config}
+            else:
+                log.debug('Element config: %s',element_config)
 
             element_class = self.PIPELINE_OPS.get(element_name, None)
+
+            log.debug('CHECKPOINT: Pipeline: %s; element name: %s; class: %s',self.name,element_name, element_class)
 
             if element_class:
                 log.info('Pipeline %s adding element name %s '

--- a/src/ambianic/pipeline/interpreter.py
+++ b/src/ambianic/pipeline/interpreter.py
@@ -324,7 +324,7 @@ class Pipeline(ManagedService):
         if ai_element is None:
             log.warning('No ai_element in element_def')
             return True
-        else
+        else:
             log.debug('AI element is not none')
 
         ai_model_id = None
@@ -339,7 +339,7 @@ class Pipeline(ManagedService):
         if ai_model_id is None:
             log.warning('AI model not found')
             return True
-        else
+        else:
             log.debug('AI model found: %s', ai_model_id)
 
         ai_model = config_manager.get_ai_model(ai_model_id)
@@ -350,7 +350,7 @@ class Pipeline(ManagedService):
                 self.name,
             )
             return False
-        else
+        else:
             log.debug("Pipeline %s; AI model configured: %s", self.name, ai_model_id)
 
         # merge the model config but keep the pipe element specific one

--- a/src/ambianic/pipeline/interpreter.py
+++ b/src/ambianic/pipeline/interpreter.py
@@ -317,18 +317,20 @@ class Pipeline(ManagedService):
         for element_name in element_def:
             # ai_model: accept just a source_id and take it from sources
             if "ai_model" in element_def[element_name]:
-                log.debug('AI model defined')
+                log.debug('AI model definition %s', element_name)
                 ai_element = element_def[element_name]
                 break
 
         if ai_element is None:
-            log.warning('No ai_element')
+            log.warning('No ai_element in element_def')
             return True
+        else
+            log.debug('AI element is not none')
 
         ai_model_id = None
         if isinstance(ai_element["ai_model"], str):
-            log.debug('AI model is string')
             ai_model_id = ai_element["ai_model"]
+            log.debug('AI model id: %s', ai_model_id)
 
         if ai_element["ai_model"] is not None and "ai_model_id" in ai_element["ai_model"]:
             log.debug('AI model found')
@@ -337,6 +339,8 @@ class Pipeline(ManagedService):
         if ai_model_id is None:
             log.warning('AI model not found')
             return True
+        else
+            log.debug('AI model found: %s', ai_model_id)
 
         ai_model = config_manager.get_ai_model(ai_model_id)
         if ai_model is None:
@@ -346,6 +350,8 @@ class Pipeline(ManagedService):
                 self.name,
             )
             return False
+        else
+            log.debug("Pipeline %s; AI model configured: %s", self.name, ai_model_id)
 
         # merge the model config but keep the pipe element specific one
         for key, val in ai_model.to_values().items():

--- a/src/ambianic/pipeline/interpreter.py
+++ b/src/ambianic/pipeline/interpreter.py
@@ -263,21 +263,23 @@ class Pipeline(ManagedService):
                 # if it is a dict (eg. in tests)
                 element_def = copy.deepcopy(_element_config)
 
-            log.info('Pipeline %s loading next element: %s',
-                     self.name, element_def)
+            log.info('Pipeline %s loading next element: %s', self.name, element_def)
 
             is_valid = self.parse_source_config(element_def)
             if not is_valid:
+                log.warning('FAILED: Pipeline: %s; source: %s',self.name, element_def)
                 self._pipe_elements = []
                 break
 
             is_valid = self.parse_ai_model_config(element_def)
             if not is_valid:
+                log.warning('FAILED: Pipeline: %s; ai_model: %s',self.name, element_def)
                 self._pipe_elements = []
                 break
 
             element_name = [*element_def][0]
             assert element_name
+            log.debug('SUCCESS: Pipeline: %s; element: %s',self.name,element_name)
             element_config = element_def[element_name]
 
             # if dealing with a static reference, pass the whole object
@@ -302,6 +304,7 @@ class Pipeline(ManagedService):
                     )
                 self._pipe_elements.append(element)
             else:
+                log.warning('Pipe element failed %s', element_name)
                 self._on_unknown_pipe_element(name=element_name)
 
     def parse_ai_model_config(self, element_def: dict):
@@ -316,6 +319,7 @@ class Pipeline(ManagedService):
                 break
 
         if ai_element is None:
+            log.debug('No ai_element')
             return True
 
         ai_model_id = None

--- a/src/ambianic/pipeline/interpreter.py
+++ b/src/ambianic/pipeline/interpreter.py
@@ -248,11 +248,13 @@ class Pipeline(ManagedService):
         """load pipeline elements based on configuration"""
         self._pipe_elements = []
 
-        log.debug('Pipeline starts with element %r', self.config[0])
+        log.debug('Pipeline first element: %r', self.config[0])
         source_element_key = [*self.config[0]][0]
-        assert source_element_key == 'source', \
-            "Pipeline config must begin with a 'source' element instead of {}"\
-            .format(source_element_key)
+        log.debug('First element key: %s', source_element_key)
+
+        assert source_element_key == 'source', "Pipeline config must begin with a 'source' element instead of {}" .format(source_element_key)
+
+        log.debug('CHECKPOINT: First element is source')
 
         for _element_config in self.config:
 

--- a/src/ambianic/pipeline/interpreter.py
+++ b/src/ambianic/pipeline/interpreter.py
@@ -297,8 +297,9 @@ class Pipeline(ManagedService):
 
             element_class = self.PIPELINE_OPS.get(element_name, None)
             if element_class:
-                log.debug('ELEMENT SUCCESS: pipeline %s; name: %s; class: %s',self.name,element_name,element_class)
+                log.debug('ELEMENT CLASS: pipeline %s; name: %s; class: %s',self.name,element_name,element_class)
                 element = element_class( **element_config, element_name=element_name, context=self._context, event_log=self._event_log)
+                log.debug('ELEMENT: pipeline %s; name: %s; class: %s; element: %r',self.name,element_name,element_class,element)
                 self._pipe_elements.append(element)
             else:
                 log.warning('ELEMENT FAILED: pipeline: %s; name: %s; config: %r',self.name,element_name,element_config)

--- a/src/ambianic/server.py
+++ b/src/ambianic/server.py
@@ -198,7 +198,7 @@ class AmbianicServer:
 
     def start(self):
         """Programmatic start of the main service."""
-        log.info('Configuring Ambianic server...')
+        print('Configuring Ambianic server...')
         config = _configure(self._env_work_dir)
         if not config:
             log.info('No startup configuration provided. '
@@ -214,7 +214,9 @@ class AmbianicServer:
         try:
             for s_name, s_class in ROOT_SERVERS.items():
                 srv = s_class(config=config)
+                log.debug('Service starting')
                 srv.start()
+                log.debug('Service started')
                 servers[s_name] = srv
 
             self._latest_heartbeat = time.monotonic()

--- a/src/ambianic/server.py
+++ b/src/ambianic/server.py
@@ -198,7 +198,7 @@ class AmbianicServer:
 
     def start(self):
         """Programmatic start of the main service."""
-        print("Starting server...")
+        log.info('Configuring Ambianic server...')
         config = _configure(self._env_work_dir)
         if not config:
             log.info('No startup configuration provided. '
@@ -225,6 +225,7 @@ class AmbianicServer:
                 time.sleep(0.5)
                 self._healthcheck(servers)
                 self._heartbeat()
+                log.debug('Watchdog')
 
         except ServiceExit:
             log.info('Service exit requested.')


### PR DESCRIPTION
Added and changed log messages to conform to pattern associated with pipeline configuration processing for the purposes of debugging.

I observe no changes in operational functionality of this repository, but did identify a requirement for `source_id` to be added to the `sources:` section in the `config.yaml` file; FWIW, it worked for me.

I am generating the `config.yaml` as part of a Home Assistant addon for ambianic; see http://github.com/dcmartin/hassio-addons and the `ambianic/` directory; building the container requires a clone of the `ambianic-edge` repository to be in the `ambianic-edge/` directory.

I made changes to the return values from True to False in the `pipeline/interpreter.py` (see line 319 for example) when the conditional indicated a failure.

I am still failing to establish complete functionality using the addon (AFAICT), but the PWA is now connecting.