### PR TITLE
feat: initial picamera support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode/
 .idea/
 .DS_Store
 ._.DS_Store

--- a/ambianic-debug.sh
+++ b/ambianic-debug.sh
@@ -27,6 +27,11 @@ docker pull ambianic/ambianic-edge:dev
 docker run -it --rm \
   --name ambianic-edge-dev \
   --mount type=bind,source="$MY_DIR",target=/workspace \
+  -v /opt/vc:/opt/vc \
+  -v /sys/class/gpio:/sys/class/gpio \
+  -v /dev:/dev \
+  --device /dev/gpiomem \
+  --privileged \
   --net=host \
   $VIDEO_ARG \
   $USB_ARG \

--- a/ambianic-debug.sh
+++ b/ambianic-debug.sh
@@ -28,9 +28,6 @@ docker run -it --rm \
   --name ambianic-edge-dev \
   --mount type=bind,source="$MY_DIR",target=/workspace \
   -v /opt/vc:/opt/vc \
-  -v /sys/class/gpio:/sys/class/gpio \
-  -v /dev:/dev \
-  --device /dev/gpiomem \
   --privileged \
   --net=host \
   $VIDEO_ARG \

--- a/ambianic-debug.sh
+++ b/ambianic-debug.sh
@@ -15,6 +15,14 @@ else
   USB_ARG=""
 fi
 
+
+VC_SHARED_LIB=""
+if grep -s -q "Raspberry Pi" /proc/cpuinfo;
+then
+  VC_SHARED_LIB="-v /opt/vc:/opt/vc"
+fi
+
+
 if [ -e "$VIDEO_0" ]; then
   VIDEO_ARG="--device $VIDEO_0"
 else
@@ -27,7 +35,7 @@ docker pull ambianic/ambianic-edge:dev
 docker run -it --rm \
   --name ambianic-edge-dev \
   --mount type=bind,source="$MY_DIR",target=/workspace \
-  -v /opt/vc:/opt/vc \
+  $VC_SHARED_LIB \
   --privileged \
   --net=host \
   $VIDEO_ARG \

--- a/build/install_requirements.sh
+++ b/build/install_requirements.sh
@@ -50,16 +50,22 @@ if $(arch | grep -q arm)
 # there is no RPI firmware in docker images, so we will install on ARM flag
 #if grep -s -q "Raspberry Pi" /sys/firmware/devicetree/base/model; then
 then
-  echo "Installing Raspberry Pi / ARM CPU specific dependencies"
-  sudo pip3 install --upgrade RPi.GPIO picamera
+  # avoid install during CI builds
+  if [ ! $TRAVIS ] ; then
+    echo "Installing Raspberry Pi / ARM CPU specific dependencies"
+    sudo pip3 install --upgrade RPi.GPIO picamera
+  fi
+
   # sudo apt-get install -y modprobe
   # Add v4l2 video module to kernel
   #  if ! grep -q "bcm2835-v4l2" /etc/modules; then
   #    echo bcm2835-v4l2 | sudo tee -a /etc/modules
   #  fi
   #  sudo modprobe bcm2835-v4l2
+
   # Enable python wheels for rpi
   sudo cp raspberrypi.pip.conf /etc/pip.conf
+  
 fi
 
 # install python dependencies

--- a/build/install_requirements.sh
+++ b/build/install_requirements.sh
@@ -52,7 +52,7 @@ if $(arch | grep -q arm)
 #if grep -s -q "Raspberry Pi" /sys/firmware/devicetree/base/model; then
 then
   echo "Installing Raspberry Pi / ARM CPU specific dependencies"
-  sudo pip3 install --upgrade RPi.GPIO
+  sudo pip3 install --upgrade RPi.GPIO picamera
   # 2020-09-14 this install 0.65 which seems incompatible with RPI4
   ##  sudo apt-get install -y python3-rpi.gpio
   # sudo apt-get install -y modprobe

--- a/build/install_requirements.sh
+++ b/build/install_requirements.sh
@@ -47,9 +47,10 @@ sudo apt-get install -y libjpeg-dev zlib1g-dev
 # echo "export PYTHONPATH=$PYTHONPATH:/usr/lib/python3/dist-packages" >> $HOME/.bashrc
 
 # Install Raspberry Pi video drivers
-if $(arch | grep -q arm)
+# if $(arch | grep -q arm)
 # there is no RPI firmware in docker images, so we will install on ARM flag
 #if grep -s -q "Raspberry Pi" /sys/firmware/devicetree/base/model; then
+if grep -s -q "Raspberry Pi" /proc/cpuinfo;
 then
   echo "Installing Raspberry Pi / ARM CPU specific dependencies"
   sudo pip3 install --upgrade RPi.GPIO picamera

--- a/build/install_requirements.sh
+++ b/build/install_requirements.sh
@@ -57,8 +57,6 @@ if grep -s -q "Raspberry Pi" /proc/cpuinfo;
 then
   echo "Installing Raspberry Pi / ARM CPU specific dependencies"
   sudo pip3 install --upgrade RPi.GPIO picamera
-  # 2020-09-14 this install 0.65 which seems incompatible with RPI4
-  ##  sudo apt-get install -y python3-rpi.gpio
   # sudo apt-get install -y modprobe
   # Add v4l2 video module to kernel
   #  if ! grep -q "bcm2835-v4l2" /etc/modules; then

--- a/build/install_requirements.sh
+++ b/build/install_requirements.sh
@@ -39,7 +39,7 @@ sudo apt-get install -y libgstreamer1.0-0 gstreamer1.0-plugins-base \
 # install numpy native lib
 sudo apt-get install -y python3-numpy
 sudo apt-get install -y libjpeg-dev zlib1g-dev
-sudo apt-get install -y libssl-dev
+sudo apt-get install -y libssl-dev pkg-config libhdf5-100 libhdf5-dev
 # [backend]
 
 # make sure python sees the packages installed via apt-get

--- a/build/install_requirements.sh
+++ b/build/install_requirements.sh
@@ -46,6 +46,9 @@ sudo apt-get install -y libssl-dev pkg-config libhdf5-103 libhdf5-dev
 # export PYTHONPATH=$PYTHONPATH:/usr/lib/python3/dist-packages
 # echo "export PYTHONPATH=$PYTHONPATH:/usr/lib/python3/dist-packages" >> $HOME/.bashrc
 
+pip3 --version
+sudo pip3 install -U pip
+
 # Install Raspberry Pi video drivers
 # if $(arch | grep -q arm)
 # there is no RPI firmware in docker images, so we will install on ARM flag
@@ -66,9 +69,12 @@ then
   sudo cp raspberrypi.pip.conf /etc/pip.conf
 fi
 
+
+# install cython v0.29 to address a compile time bug for h5py
+# see https://github.com/h5py/h5py/issues/1533#issuecomment-617519250
+sudo pip3 install cython
+
 # install python dependencies
-pip3 --version
-sudo pip3 install -U pip
 sudo pip3 install -r requirements.txt
 
   # install gcc as some of the python native dependencies

--- a/build/install_requirements.sh
+++ b/build/install_requirements.sh
@@ -39,7 +39,7 @@ sudo apt-get install -y libgstreamer1.0-0 gstreamer1.0-plugins-base \
 # install numpy native lib
 sudo apt-get install -y python3-numpy
 sudo apt-get install -y libjpeg-dev zlib1g-dev
-
+sudo apt-get install -y libssl-dev
 # [backend]
 
 # make sure python sees the packages installed via apt-get

--- a/build/install_requirements.sh
+++ b/build/install_requirements.sh
@@ -51,10 +51,9 @@ if $(arch | grep -q arm)
 #if grep -s -q "Raspberry Pi" /sys/firmware/devicetree/base/model; then
 then
   # avoid install during CI builds
-  if [ ! $TRAVIS ] ; then
-    echo "Installing Raspberry Pi / ARM CPU specific dependencies"
-    sudo pip3 install --upgrade RPi.GPIO picamera
-  fi
+  export READTHEDOCS=True
+  echo "Installing Raspberry Pi / ARM CPU specific dependencies"
+  sudo pip3 install --upgrade RPi.GPIO picamera
 
   # sudo apt-get install -y modprobe
   # Add v4l2 video module to kernel

--- a/build/install_requirements.sh
+++ b/build/install_requirements.sh
@@ -39,18 +39,14 @@ sudo apt-get install -y libgstreamer1.0-0 gstreamer1.0-plugins-base \
 # install numpy native lib
 sudo apt-get install -y python3-numpy
 sudo apt-get install -y libjpeg-dev zlib1g-dev
-sudo apt-get install -y libssl-dev pkg-config libhdf5-103 libhdf5-dev
 # [backend]
 
 # make sure python sees the packages installed via apt-get
 # export PYTHONPATH=$PYTHONPATH:/usr/lib/python3/dist-packages
 # echo "export PYTHONPATH=$PYTHONPATH:/usr/lib/python3/dist-packages" >> $HOME/.bashrc
 
-pip3 --version
-sudo pip3 install -U pip
-
 # Install Raspberry Pi video drivers
-# if $(arch | grep -q arm)
+if $(arch | grep -q arm)
 # there is no RPI firmware in docker images, so we will install on ARM flag
 #if grep -s -q "Raspberry Pi" /sys/firmware/devicetree/base/model; then
 if grep -s -q "Raspberry Pi" /proc/cpuinfo;
@@ -67,12 +63,9 @@ then
   sudo cp raspberrypi.pip.conf /etc/pip.conf
 fi
 
-
-# install cython v0.29 to address a compile time bug for h5py
-# see https://github.com/h5py/h5py/issues/1533#issuecomment-617519250
-sudo pip3 install cython
-
 # install python dependencies
+pip3 --version
+sudo pip3 install -U pip
 sudo pip3 install -r requirements.txt
 
   # install gcc as some of the python native dependencies

--- a/build/install_requirements.sh
+++ b/build/install_requirements.sh
@@ -51,9 +51,8 @@ if $(arch | grep -q arm)
 #if grep -s -q "Raspberry Pi" /sys/firmware/devicetree/base/model; then
 then
   # avoid install during CI builds
-  export READTHEDOCS=True
   echo "Installing Raspberry Pi / ARM CPU specific dependencies"
-  sudo pip3 install --upgrade RPi.GPIO picamera
+  sudo READTHEDOCS=True pip3 install --upgrade RPi.GPIO picamera
 
   # sudo apt-get install -y modprobe
   # Add v4l2 video module to kernel

--- a/build/install_requirements.sh
+++ b/build/install_requirements.sh
@@ -52,7 +52,9 @@ if $(arch | grep -q arm)
 #if grep -s -q "Raspberry Pi" /sys/firmware/devicetree/base/model; then
 then
   echo "Installing Raspberry Pi / ARM CPU specific dependencies"
-  sudo apt-get install -y python3-rpi.gpio
+  sudo pip3 install --upgrade RPi.GPIO
+  # 2020-09-14 this install 0.65 which seems incompatible with RPI4
+  ##  sudo apt-get install -y python3-rpi.gpio
   # sudo apt-get install -y modprobe
   # Add v4l2 video module to kernel
   #  if ! grep -q "bcm2835-v4l2" /etc/modules; then

--- a/build/install_requirements.sh
+++ b/build/install_requirements.sh
@@ -39,7 +39,7 @@ sudo apt-get install -y libgstreamer1.0-0 gstreamer1.0-plugins-base \
 # install numpy native lib
 sudo apt-get install -y python3-numpy
 sudo apt-get install -y libjpeg-dev zlib1g-dev
-sudo apt-get install -y libssl-dev pkg-config libhdf5-100 libhdf5-dev
+sudo apt-get install -y libssl-dev pkg-config libhdf5-103 libhdf5-dev
 # [backend]
 
 # make sure python sees the packages installed via apt-get

--- a/build/install_requirements.sh
+++ b/build/install_requirements.sh
@@ -49,7 +49,6 @@ sudo apt-get install -y libjpeg-dev zlib1g-dev
 if $(arch | grep -q arm)
 # there is no RPI firmware in docker images, so we will install on ARM flag
 #if grep -s -q "Raspberry Pi" /sys/firmware/devicetree/base/model; then
-if grep -s -q "Raspberry Pi" /proc/cpuinfo;
 then
   echo "Installing Raspberry Pi / ARM CPU specific dependencies"
   sudo pip3 install --upgrade RPi.GPIO picamera

--- a/config.yaml
+++ b/config.yaml
@@ -28,16 +28,17 @@ sources:
   #   type: video
   #   live: true
 
+  # direct support for picamera
+  picamera:
+    uri: picamera
+    type: video
+    live: true
+
   # local video device integration example
   webcam:
     uri: /dev/video0
     type: video
     live: true
-
-  um:uuid:5f5a69c2-e0ae-504f-829b-0076E58E0DDE:
-    live: true
-    type: video
-    uri: rtsp://192.168.7.13:554/11
 
   recorded_cam_feed:
     uri: file:///workspace/tests/pipeline/avsource/test2-cam-person1.mkv
@@ -64,7 +65,7 @@ ai_models:
 # such as reading from a data source, AI model inference, saving samples and others.
 pipelines:
   front_door_watch:
-    - source: webcam
+    - source: picamera
     - detect_objects: # run ai inference on the input data
        ai_model: image_detection
        confidence_threshold: 0.8

--- a/config.yaml
+++ b/config.yaml
@@ -28,7 +28,7 @@ sources:
   #   type: video
   #   live: true
 
-  # direct support for picamera
+  # direct support for raspberry picamera
   picamera:
     uri: picamera
     type: video

--- a/src/ambianic/pipeline/avsource/av_element.py
+++ b/src/ambianic/pipeline/avsource/av_element.py
@@ -118,7 +118,6 @@ class AVSourceElement(PipeElement):
             except Exception as err:
                 log.debug("Error acquiring from picamera: %s" % err)
                 time.sleep(1)
-                pass
 
         picamera.stop()
 

--- a/src/ambianic/pipeline/avsource/av_element.py
+++ b/src/ambianic/pipeline/avsource/av_element.py
@@ -11,7 +11,6 @@ import requests
 from ambianic.util import stacktrace
 from ambianic.pipeline import PipeElement
 from ambianic.pipeline.avsource import gst_process
-import picamera
 
 log = logging.getLogger(__name__)
 
@@ -106,6 +105,8 @@ class AVSourceElement(PipeElement):
         time.sleep(1)
 
     def _run_picamera_fetch(self):
+        # avoid unit testing to fail when env is not PI
+        import picamera
         camera = picamera.PiCamera()
         stream = BytesIO()
         camera.led = True

--- a/src/ambianic/pipeline/avsource/av_element.py
+++ b/src/ambianic/pipeline/avsource/av_element.py
@@ -11,6 +11,7 @@ import requests
 from ambianic.util import stacktrace
 from ambianic.pipeline import PipeElement
 from ambianic.pipeline.avsource import gst_process
+import picamera
 
 log = logging.getLogger(__name__)
 
@@ -104,6 +105,22 @@ class AVSourceElement(PipeElement):
         log.debug("Pausing for a moment to let remote network issues settle")
         time.sleep(1)
 
+    def _run_picamera_fetch(self):
+        camera = picamera.PiCamera()
+        stream = BytesIO()
+        camera.led = True
+        camera.start_preview()
+        time.sleep(2)
+
+        # todo: setup or expose ISO shutter awb properties
+        while not self._stop_requested:
+            camera.capture(stream, format='jpeg')
+            stream.seek(0)
+            image = Image.open(stream)
+            self.receive_next_sample(image=image)
+
+        camera.led = False
+
     def _run_http_fetch(self, url=None, continuous=False):
         log.debug("Fetching source uri sample over http: %r", url)
         assert url
@@ -133,8 +150,6 @@ class AVSourceElement(PipeElement):
                     log.debug('Completed one time http image fetch from URL: %r',
                             url)
                     break
-
-
 
     def _run_gst_service(self):
         log.debug("Starting Gst service process...")
@@ -258,7 +273,11 @@ class AVSourceElement(PipeElement):
         super().start()
         log.info("Starting %s", self.__class__.__name__)
         self._stop_requested = False
-        if self._source_conf['uri'].startswith('http') and \
+
+        if self._source_conf['uri'] == "picamera":
+            log.debug("Input source is picamera")
+            self._run_picamera_fetch()
+        elif self._source_conf['uri'].startswith('http') and \
             self._source_conf['type'] == 'image':
             log.debug("""
                 Input source is an http still image: %r

--- a/src/ambianic/pipeline/avsource/av_element.py
+++ b/src/ambianic/pipeline/avsource/av_element.py
@@ -111,8 +111,7 @@ class AVSourceElement(PipeElement):
         camera.led = True
         camera.start_preview()
         time.sleep(2)
-
-        # todo: setup or expose ISO shutter awb properties
+        # note: setup or expose ISO shutter awb properties
         while not self._stop_requested:
             camera.capture(stream, format='jpeg')
             stream.seek(0)

--- a/src/ambianic/pipeline/avsource/picam.py
+++ b/src/ambianic/pipeline/avsource/picam.py
@@ -15,14 +15,9 @@ class Picamera():
         self.format = image_format
 
         if picamera_override is None:
-
             try:
                 import picamera
                 self.camera = picamera.PiCamera()
-            except ImportError as err:
-                log.warning("Failed to import picamera module: %s" % err)
-                self.error = err
-                return
             except Exception as err:
                 log.warning("Error importing picamera module: %s" % err)
                 self.error = err
@@ -39,8 +34,6 @@ class Picamera():
         return self.error is not None
 
     def acquire(self):
-        if self.has_failure():
-            return None
         self.camera.capture(self.stream, format=self.format)
         self.stream.seek(0)
         return Image.open(self.stream)

--- a/src/ambianic/pipeline/avsource/picam.py
+++ b/src/ambianic/pipeline/avsource/picam.py
@@ -1,0 +1,54 @@
+import logging
+from io import BytesIO
+import time
+from PIL import Image
+
+log = logging.getLogger(__name__)
+
+picamera_override = None
+
+class Picamera():
+
+    def __init__(self, image_format='jpeg'):
+
+        self.error = None
+        self.format = image_format
+
+        if picamera_override is None:
+
+            try:
+                import picamera
+                self.camera = picamera.PiCamera()
+            except ImportError as err:
+                log.warn("Failed to import picamera module: %s" % err)
+                self.error = err
+                return
+            except Exception as err:
+                log.warn("Error importing picamera module: %s" % err)
+                self.error = err
+                return
+        else:
+            self.camera = picamera_override.PiCamera()
+
+        self.stream = BytesIO()
+        self.camera.led = True
+        self.camera.start_preview()
+        # note: setup or expose properties (ISO shutter awb)
+        time.sleep(2)
+
+    def has_failure(self):
+        return self.error is not None
+
+    def acquire(self):
+        if self.has_failure():
+            return None
+        self.camera.capture(self.stream, format=self.format)
+        self.stream.seek(0)
+        return Image.open(self.stream)
+
+    def stop(self):
+        if self.stream is not None:
+            self.stream.close()
+        if self.camera is not None:
+            self.camera.led = False
+            self.camera.close()

--- a/src/ambianic/pipeline/avsource/picam.py
+++ b/src/ambianic/pipeline/avsource/picam.py
@@ -32,7 +32,6 @@ class Picamera():
 
         self.stream = BytesIO()
         self.camera.led = True
-        self.camera.start_preview()
         # note: setup or expose properties (ISO shutter awb)
         time.sleep(2)
 

--- a/src/ambianic/pipeline/avsource/picam.py
+++ b/src/ambianic/pipeline/avsource/picam.py
@@ -20,11 +20,11 @@ class Picamera():
                 import picamera
                 self.camera = picamera.PiCamera()
             except ImportError as err:
-                log.warn("Failed to import picamera module: %s" % err)
+                log.warning("Failed to import picamera module: %s" % err)
                 self.error = err
                 return
             except Exception as err:
-                log.warn("Error importing picamera module: %s" % err)
+                log.warning("Error importing picamera module: %s" % err)
                 self.error = err
                 return
         else:

--- a/src/run-dev.sh
+++ b/src/run-dev.sh
@@ -1,3 +1,4 @@
+export LD_LIBRARY_PATH=/opt/vc/lib
 cd /workspace
 pip3 install -e src
 python3 -m ambianic

--- a/src/setup.cfg
+++ b/src/setup.cfg
@@ -24,5 +24,4 @@ python_requires = >=3.6
 install_requires = 
 	concurrent-log-handler
 	inotify_simple
-	picamera
 

--- a/src/setup.cfg
+++ b/src/setup.cfg
@@ -24,4 +24,5 @@ python_requires = >=3.6
 install_requires = 
 	concurrent-log-handler
 	inotify_simple
+	picamera
 

--- a/tests/pipeline/avsource/test_avsource.py
+++ b/tests/pipeline/avsource/test_avsource.py
@@ -11,7 +11,7 @@ from ambianic.pipeline.ai.object_detect import ObjectDetector
 from ambianic.pipeline.avsource.gst_process import GstService
 import logging
 
-from test_avsource_picamera import picamera_override_failure
+from test_avsource_picamera import picamera_override_failure, picamera_override
 from ambianic.pipeline.avsource.av_element import picam
 
 log = logging.getLogger()
@@ -341,9 +341,9 @@ def test_picamera_fail_import():
     assert not t.is_alive()
 
 
-def test_picamera_input_exit_stop_signal():
+def test_picamera_input():
     # mock picamera module
-    picam.picamera_override = picamera_override_failure
+    picam.picamera_override = picamera_override
 
     avsource = AVSourceElement(uri="picamera", type='video')
     object_config = _object_detect_config()
@@ -372,7 +372,7 @@ def test_picamera_input_exit_stop_signal():
     t = threading.Thread(
         name="Test AVSourceElement",
         target=avsource.start, daemon=True
-        )
+    )
     t.start()
     detection_received.wait(timeout=10)
     assert sample_image
@@ -385,6 +385,21 @@ def test_picamera_input_exit_stop_signal():
     assert confidence > 0.9
     assert x0 > 0 and x0 < x1
     assert y0 > 0 and y0 < y1
+    avsource.stop()
+    t.join(timeout=10)
+    assert not t.is_alive()
+
+
+def test_picamera_input_fail():
+    # mock picamera module
+    picam.picamera_override = picamera_override_failure
+    avsource = AVSourceElement(uri="picamera", type='video')
+    t = threading.Thread(
+        name="Test AVSourceElement",
+        target=avsource.start, daemon=True
+    )
+    t.start()
+    time.sleep(1)
     avsource.stop()
     t.join(timeout=10)
     assert not t.is_alive()

--- a/tests/pipeline/avsource/test_avsource.py
+++ b/tests/pipeline/avsource/test_avsource.py
@@ -18,10 +18,6 @@ log = logging.getLogger()
 log.setLevel(logging.DEBUG)
 
 
-def test_no_config():
-    with pytest.raises(AssertionError):
-        AVSourceElement()
-
 
 class _TestAVSourceElement(AVSourceElement):
 
@@ -334,13 +330,15 @@ def test_picamera_fail_import():
     # mock picamera module
     picam.picamera_override = None
 
-
     avsource = AVSourceElement(uri="picamera", type='video')
     t = threading.Thread(
-        name="Test AVSourceElement",
+        name="Test AVSourceElement Picamera",
         target=avsource.start, daemon=True
     )
     t.start()
+    time.sleep(1)
+    t.join(timeout=10)
+    assert not t.is_alive()
 
 
 def test_picamera_input_exit_stop_signal():

--- a/tests/pipeline/avsource/test_avsource.py
+++ b/tests/pipeline/avsource/test_avsource.py
@@ -11,6 +11,9 @@ from ambianic.pipeline.ai.object_detect import ObjectDetector
 from ambianic.pipeline.avsource.gst_process import GstService
 import logging
 
+from test_avsource_picamera import picamera_override
+from ambianic.pipeline.avsource.av_element import picam
+
 log = logging.getLogger()
 log.setLevel(logging.DEBUG)
 
@@ -283,6 +286,55 @@ def test_still_image_input_detect_person_exit_stop_signal():
     abs_path = os.path.abspath(video_file)
     video_uri = pathlib.Path(abs_path).as_uri()
     avsource = AVSourceElement(uri=video_uri, type='image')
+    object_config = _object_detect_config()
+    detection_received = threading.Event()
+    sample_image = None
+    detections = None
+
+    def sample_callback(image=None, inference_result=None, **kwargs):
+        nonlocal sample_image
+        nonlocal detection_received
+        sample_image = image
+        nonlocal detections
+        detections = inference_result
+        print('detections: {det}'.format(det=detections))
+        print('len(detections): {len}'.format(len=len(detections)))
+        if detections:
+            label, confidence, _ = detections[0]
+            if label == 'person' and confidence > 0.9:
+                # skip video image samples until we reach a person detection
+                # with high level of confidence
+                detection_received.set()
+    object_detector = ObjectDetector(**object_config)
+    avsource.connect_to_next_element(object_detector)
+    output = _OutPipeElement(sample_callback=sample_callback)
+    object_detector.connect_to_next_element(output)
+    t = threading.Thread(
+        name="Test AVSourceElement",
+        target=avsource.start, daemon=True
+        )
+    t.start()
+    detection_received.wait(timeout=10)
+    assert sample_image
+    assert sample_image.size[0] == 1280
+    assert sample_image.size[1] == 720
+    assert detections
+    assert len(detections) == 1
+    label, confidence, (x0, y0, x1, y1) = detections[0]
+    assert label == 'person'
+    assert confidence > 0.9
+    assert x0 > 0 and x0 < x1
+    assert y0 > 0 and y0 < y1
+    avsource.stop()
+    t.join(timeout=10)
+    assert not t.is_alive()
+
+def test_picamera_input_exit_stop_signal():
+
+    # mock picamera module
+    picam.picamera_override = picamera_override
+
+    avsource = AVSourceElement(uri="picamera", type='video')
     object_config = _object_detect_config()
     detection_received = threading.Event()
     sample_image = None

--- a/tests/pipeline/avsource/test_avsource.py
+++ b/tests/pipeline/avsource/test_avsource.py
@@ -11,7 +11,7 @@ from ambianic.pipeline.ai.object_detect import ObjectDetector
 from ambianic.pipeline.avsource.gst_process import GstService
 import logging
 
-from test_avsource_picamera import picamera_override
+from test_avsource_picamera import picamera_override_failure
 from ambianic.pipeline.avsource.av_element import picam
 
 log = logging.getLogger()
@@ -343,7 +343,7 @@ def test_picamera_fail_import():
 
 def test_picamera_input_exit_stop_signal():
     # mock picamera module
-    picam.picamera_override = picamera_override
+    picam.picamera_override = picamera_override_failure
 
     avsource = AVSourceElement(uri="picamera", type='video')
     object_config = _object_detect_config()

--- a/tests/pipeline/avsource/test_avsource.py
+++ b/tests/pipeline/avsource/test_avsource.py
@@ -329,8 +329,21 @@ def test_still_image_input_detect_person_exit_stop_signal():
     t.join(timeout=10)
     assert not t.is_alive()
 
-def test_picamera_input_exit_stop_signal():
 
+def test_picamera_fail_import():
+    # mock picamera module
+    picam.picamera_override = None
+
+
+    avsource = AVSourceElement(uri="picamera", type='video')
+    t = threading.Thread(
+        name="Test AVSourceElement",
+        target=avsource.start, daemon=True
+    )
+    t.start()
+
+
+def test_picamera_input_exit_stop_signal():
     # mock picamera module
     picam.picamera_override = picamera_override
 

--- a/tests/pipeline/avsource/test_avsource_picamera.py
+++ b/tests/pipeline/avsource/test_avsource_picamera.py
@@ -27,7 +27,7 @@ class _TestPiCamera():
         pass
 
     def capture(self, stream, format):
-        if self.fail_read and self.read % 2 == 0:
+        if self.fail_read and (self.read > 0 and self.read % 2 == 0):
             raise Exception("Read failed")
         img = Image.open(self.img_path, mode='r')
         img.save(stream, format=format)
@@ -66,6 +66,8 @@ def test_acquire_failure():
     assert not cam.has_failure()
     failed = False
     try:
+        cam.acquire()
+        cam.acquire()
         cam.acquire()
     except Exception:
         failed = True

--- a/tests/pipeline/avsource/test_avsource_picamera.py
+++ b/tests/pipeline/avsource/test_avsource_picamera.py
@@ -21,7 +21,6 @@ class _TestPiCamera():
         )
 
         self.led = False
-        pass
     
     def start_preview(self):
         pass

--- a/tests/pipeline/avsource/test_avsource_picamera.py
+++ b/tests/pipeline/avsource/test_avsource_picamera.py
@@ -1,0 +1,51 @@
+"""Test audio/video source pipeline element."""
+import pytest
+from ambianic.pipeline.avsource.av_element import picam
+import logging
+from io import BytesIO
+import time
+import os
+from PIL import Image
+
+log = logging.getLogger()
+log.setLevel(logging.DEBUG)
+
+class _TestPiCamera():
+
+    def __init__(self):
+
+        _dir = os.path.dirname(os.path.abspath(__file__))
+        self.img_path = os.path.join(
+            _dir,
+            '../ai/person.jpg'
+        )
+
+        self.led = False
+        pass
+    
+    def start_preview(self):
+        pass
+
+    def capture(self, stream, format):
+        img = Image.open(self.img_path, mode='r')
+        img.save(stream, format=format)
+
+    def close(self): 
+        pass
+
+
+class picamera_override():
+    PiCamera = _TestPiCamera
+
+def test_fail_import():
+    picam.picamera_override = None
+    cam = picam.Picamera()
+    assert cam.has_failure()
+
+def test_acquire():
+    picam.picamera_override = picamera_override
+    cam = picam.Picamera()
+    assert not cam.has_failure()
+    raw = cam.acquire()
+    assert raw is not None
+    cam.stop()

--- a/tests/pipeline/avsource/test_avsource_picamera.py
+++ b/tests/pipeline/avsource/test_avsource_picamera.py
@@ -19,7 +19,6 @@ class _TestPiCamera():
             _dir,
             '../ai/person.jpg'
         )
-        self.read = 0
         self.fail_read = fail_read
         self.led = False
     
@@ -27,11 +26,10 @@ class _TestPiCamera():
         pass
 
     def capture(self, stream, format):
-        if self.fail_read and (self.read > 0 and self.read % 2 == 0):
+        if self.fail_read:
             raise Exception("Read failed")
         img = Image.open(self.img_path, mode='r')
         img.save(stream, format=format)
-        self.read += 1
 
     def close(self): 
         pass
@@ -67,10 +65,7 @@ def test_acquire_failure():
     failed = False
     try:
         cam.acquire()
-        cam.acquire()
-        cam.acquire()
     except Exception:
         failed = True
-        pass
     assert failed
     cam.stop()

--- a/tests/pipeline/avsource/test_avsource_picamera.py
+++ b/tests/pipeline/avsource/test_avsource_picamera.py
@@ -12,29 +12,40 @@ log.setLevel(logging.DEBUG)
 
 class _TestPiCamera():
 
-    def __init__(self):
+    def __init__(self, fail_read=False):
 
         _dir = os.path.dirname(os.path.abspath(__file__))
         self.img_path = os.path.join(
             _dir,
             '../ai/person.jpg'
         )
-
+        self.read = 0
+        self.fail_read = fail_read
         self.led = False
     
     def start_preview(self):
         pass
 
     def capture(self, stream, format):
+        if self.fail_read and self.read % 2 == 0:
+            raise Exception("Read failed")
         img = Image.open(self.img_path, mode='r')
         img.save(stream, format=format)
+        self.read += 1
 
     def close(self): 
         pass
 
 
+class _TestPiCameraFailure(_TestPiCamera):
+    def __init__(self):
+        super().__init__(fail_read=True)
+
 class picamera_override():
     PiCamera = _TestPiCamera
+
+class picamera_override_failure():
+    PiCamera = _TestPiCameraFailure
 
 def test_fail_import():
     picam.picamera_override = None
@@ -47,4 +58,17 @@ def test_acquire():
     assert not cam.has_failure()
     raw = cam.acquire()
     assert raw is not None
+    cam.stop()
+
+def test_acquire_failure():
+    picam.picamera_override = picamera_override_failure
+    cam = picam.Picamera()
+    assert not cam.has_failure()
+    failed = False
+    try:
+        cam.acquire()
+    except Exception:
+        failed = True
+        pass
+    assert failed
     cam.stop()


### PR DESCRIPTION
Initial support for picamera driver. Currently seems there is a misalignment with the GPIO python module for the PI4 chipset which causes an exception in docker that follows

```sh
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.7/dist-packages/picamera/__init__.py", line 89, in <module>
    from picamera.camera import PiCamera
  File "/usr/local/lib/python3.7/dist-packages/picamera/camera.py", line 79, in <module>
    from RPi import GPIO
  File "/usr/lib/python3/dist-packages/RPi/GPIO/__init__.py", line 23, in <module>
    from RPi._GPIO import *
RuntimeError: This module can only be run on a Raspberry Pi!
```

I am investigating how to manage the issue
