### PR TITLE
fix: remove ca install on start

### DIFF
--- a/build/ambianic-docker-entrypoint.sh
+++ b/build/ambianic-docker-entrypoint.sh
@@ -5,13 +5,13 @@ set -ex
 
 # Re-Install ARM/Raspberry Pi ca-certifcates
 # Which otherwise cause SSL Certificate Verification problems.
-if $(arch | grep -q arm)
-then
-  echo "Re-Installing ca-certifcates on Raspberry Pi / ARM CPU"
-  sudo apt-get remove -y ca-certificates
-  sudo apt-get update
-  sudo apt-get install -y ca-certificates
-fi
+# if $(arch | grep -q arm)
+# then
+#   echo "Re-Installing ca-certifcates on Raspberry Pi / ARM CPU"
+#   sudo apt-get remove -y ca-certificates
+#   sudo apt-get update
+#   sudo apt-get install -y ca-certificates
+# fi
 
 python3 -m peerjs.ext.http-proxy   &
 python3 -m ambianic


### PR DESCRIPTION
test if still needed with latest rpi os