### PR TITLE
fix: adjust default confidence threshold for fall detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Semantic Versioning Changelog
 
+## [1.10.1](https://github.com/ivelin/ambianic-edge/compare/v1.10.0...v1.10.1) (2021-02-08)
+
+
+### Bug Fixes
+
+* adjust default confidence threshold for fall detection ([5a98549](https://github.com/ivelin/ambianic-edge/commit/5a9854937d3b713b704d0229783aa36fce5d7d5a))
+* search for timeline event in a flat dir only ([1838f57](https://github.com/ivelin/ambianic-edge/commit/1838f57c9472e88bb7a72622f40455098fd6deec)), closes [#297](https://github.com/ivelin/ambianic-edge/issues/297)
+
 ## [1.13.1](https://github.com/ambianic/ambianic-edge/compare/v1.13.0...v1.13.1) (2021-02-06)
 
 

--- a/build/requirements.txt
+++ b/build/requirements.txt
@@ -9,7 +9,7 @@ certifi>=2018.8.24
 chardet>=3.0.4
 Click>=7.0
 cookies>=2.2.1
-cryptography>=2.8
+cryptography>=2.8,<=3.3.2
 decorator>=4.3.0
 entrypoints>=0.3
 Flask>=1.0.2

--- a/src/ambianic/pipeline/ai/fall_detect.py
+++ b/src/ambianic/pipeline/ai/fall_detect.py
@@ -14,6 +14,7 @@ class FallDetector(TFDetectionModel):
     """Detects falls comparing two images spaced about 1-2 seconds apart."""
     def __init__(self,
                  model=None,
+                 confidence_threshold=0.25,
                  **kwargs
                  ):
         """Initialize detector with config parameters.
@@ -27,7 +28,7 @@ class FallDetector(TFDetectionModel):
                 'ai_models/posenet_mobilenet_v1_075_721_1281_quant_decoder_edgetpu.tflite'
         }
         """
-        super().__init__(model, **kwargs)
+        super().__init__(model=model, confidence_threshold=confidence_threshold, **kwargs)
 
         # previous pose detection information for frame at time t-1 and t-2 \
         # to compare pose changes against


### PR DESCRIPTION
Field tests show that 0.25 works better than 0.6.