### PR TITLE
fix: fall detection confidence_threshold propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Semantic Versioning Changelog
 
+## [1.10.2](https://github.com/ivelin/ambianic-edge/compare/v1.10.1...v1.10.2) (2021-02-09)
+
+
+### Bug Fixes
+
+* adjust default confidence threshold for fall detection ([f73e3ef](https://github.com/ivelin/ambianic-edge/commit/f73e3ef7c5c0a1e888e9f82425db3586cfb4c47d)), closes [#302](https://github.com/ivelin/ambianic-edge/issues/302)
+* debug logging issues; closes [#257](https://github.com/ivelin/ambianic-edge/issues/257); closes [#305](https://github.com/ivelin/ambianic-edge/issues/305) ([34fbe1e](https://github.com/ivelin/ambianic-edge/commit/34fbe1e545749c9af1e6735f209e0b4f1aecfd7c))
+
 ## [1.13.2](https://github.com/ambianic/ambianic-edge/compare/v1.13.1...v1.13.2) (2021-02-09)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Semantic Versioning Changelog
 
+## [1.10.3](https://github.com/ivelin/ambianic-edge/compare/v1.10.2...v1.10.3) (2021-02-10)
+
+
+### Bug Fixes
+
+* confidence_threshold propagation ([71972a7](https://github.com/ivelin/ambianic-edge/commit/71972a78a1d5346f79cbaf0f238051bd466d4ac0))
+* debug logging issues; closes [#257](https://github.com/ivelin/ambianic-edge/issues/257); closes [#305](https://github.com/ivelin/ambianic-edge/issues/305) ([ec172a8](https://github.com/ivelin/ambianic-edge/commit/ec172a8d6b83b836ef4ff364b843b1915d7d7940)), closes [#306](https://github.com/ivelin/ambianic-edge/issues/306)
+
 ## [1.13.3](https://github.com/ambianic/ambianic-edge/compare/v1.13.2...v1.13.3) (2021-02-09)
 
 

--- a/src/ambianic/pipeline/ai/inference.py
+++ b/src/ambianic/pipeline/ai/inference.py
@@ -83,7 +83,7 @@ class TFInferenceEngine:
         self._model_labels_path = labels
         self._confidence_threshold = confidence_threshold
         self._top_k = top_k
-        log.debug('Loading AI model:\n'
+        log.info('Loading AI model:\n'
                   'TFLite graph: %r\n'
                   'EdgeTPU graph: %r\n'
                   'Labels %r.'

--- a/tests/pipeline/ai/test_fall_detect_more.py
+++ b/tests/pipeline/ai/test_fall_detect_more.py
@@ -1,0 +1,64 @@
+"""Test fall detection pipe element."""
+from ambianic.pipeline.ai.fall_detect import FallDetector
+from ambianic.pipeline.ai.object_detect import ObjectDetector
+from ambianic.pipeline import PipeElement
+import os
+import time
+from PIL import Image
+
+
+def _fall_detect_config():
+
+    _dir = os.path.dirname(os.path.abspath(__file__))
+    _good_tflite_model = os.path.join(
+        _dir,
+        'posenet_mobilenet_v1_100_257x257_multi_kpt_stripped.tflite'
+        )
+    _good_edgetpu_model = os.path.join(
+        _dir,
+        'posenet_mobilenet_v1_075_721_1281_quant_decoder_edgetpu.tflite'
+        )
+    _good_labels = os.path.join(_dir, 'pose_labels.txt')
+    config = {
+        'model': {
+            'tflite': _good_tflite_model,
+            'edgetpu': _good_edgetpu_model,
+            },
+        'labels': _good_labels,
+        'top_k': 3,
+        'confidence_threshold': 0.235,
+    }
+    return config
+
+
+def test_model_inputs():
+    """Verify against known model inputs."""
+    config = _fall_detect_config()
+    fall_detector = FallDetector(**config)
+    tfe = fall_detector._tfengine
+
+    samples = tfe.input_details[0]['shape'][0]
+    assert samples == 1
+    height = tfe.input_details[0]['shape'][1]
+    assert height == 257
+    width = tfe.input_details[0]['shape'][2]
+    assert width == 257
+    colors = tfe.input_details[0]['shape'][3]
+    assert colors == 3
+
+def test_config_confidence_threshold():
+    """Verify against known confidence threshold. Make sure it propagates at all levels."""
+    config = _fall_detect_config()
+    fall_detector = FallDetector(**config)
+    tfe = fall_detector._tfengine
+    pe = fall_detector._pose_engine
+    assert fall_detector.confidence_threshold == config['confidence_threshold']
+    assert pe.confidence_threshold == config['confidence_threshold']
+    assert tfe.confidence_threshold == config['confidence_threshold']
+    config['confidence_threshold'] = 0.457
+    fall_detector = FallDetector(**config)
+    tfe = fall_detector._tfengine
+    pe = fall_detector._pose_engine
+    assert fall_detector.confidence_threshold == config['confidence_threshold']
+    assert pe.confidence_threshold == config['confidence_threshold']
+    assert tfe.confidence_threshold == config['confidence_threshold']


### PR DESCRIPTION
## [1.10.2](https://github.com/ivelin/ambianic-edge/compare/v1.10.1...v1.10.2) (2021-02-09)

### Bug Fixes

* adjust default confidence threshold for fall detection ([f73e3ef](https://github.com/ivelin/ambianic-edge/commit/f73e3ef7c5c0a1e888e9f82425db3586cfb4c47d)), closes [#302](https://github.com/ivelin/ambianic-edge/issues/302)
* debug logging issues; closes [#257](https://github.com/ivelin/ambianic-edge/issues/257); closes [#305](https://github.com/ivelin/ambianic-edge/issues/305) ([34fbe1e](https://github.com/ivelin/ambianic-edge/commit/34fbe1e545749c9af1e6735f209e0b4f1aecfd7c))