### PR TITLE
build: publish python API docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,29 @@
+name: Build Docs
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  publish_docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pdoc3
+    - name: Run build script
+      run: |
+        pdoc --html src/ambianic
+    - name: Deploy to github pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,8 +18,8 @@ jobs:
     - name: Run doc build script
       run: |
         ${GITHUB_WORKSPACE}/build/ci-docs-job.sh
-    - name: Deploy to github pages
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./docs/dist
+#    - name: Deploy to github pages
+#      uses: peaceiris/actions-gh-pages@v3
+#      with:
+#        github_token: ${{ secrets.GITHUB_TOKEN }}
+#        publish_dir: ./docs/dist

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,15 +15,11 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3
-    - name: Install dependencies
+    - name: Run doc build script
       run: |
-        python -m pip install --upgrade pip
-        pip install pdoc3
-    - name: Run build script
-      run: |
-        pdoc --html src/ambianic
+        ${GITHUB_WORKSPACE}/build/ci-docs-job.sh
     - name: Deploy to github pages
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./html
+        publish_dir: ./docs/dist

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,3 +123,26 @@ jobs:
         echo ${{ steps.semrel.outputs.new_release_major_version }}
         echo ${{ steps.semrel.outputs.new_release_minor_version }}
         echo ${{ steps.semrel.outputs.new_release_patch_version }}
+        
+        
+  publish_docs:
+    needs: [push_release]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pdoc3
+    - name: Run build script
+      run: |
+        pdoc --html src/ambianic
+    - name: Deploy to github pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./html   

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,15 +134,11 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3
-    - name: Install dependencies
+    - name: Run doc build script
       run: |
-        python -m pip install --upgrade pip
-        pip install pdoc3
-    - name: Run build script
-      run: |
-        pdoc --html src/ambianic
+        ${GITHUB_WORKSPACE}/build/ci-docs-job.sh
     - name: Deploy to github pages
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./html
+        publish_dir: ./docs/dist

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,8 +123,8 @@ jobs:
         echo ${{ steps.semrel.outputs.new_release_major_version }}
         echo ${{ steps.semrel.outputs.new_release_minor_version }}
         echo ${{ steps.semrel.outputs.new_release_patch_version }}
-        
-        
+
+
   publish_docs:
     needs: [push_release]
     runs-on: ubuntu-latest
@@ -145,4 +145,4 @@ jobs:
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./html   
+        publish_dir: ./html

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ config.yaml.local
 /.ropeproject
 tmp*.jpg
 src/Ambianic.egg-info/**
+/docs/dist

--- a/build/ci-docs-job.sh
+++ b/build/ci-docs-job.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Run testsuite within a CI workflow
+
+# set bash debug parameters
+set -exu
+
+# build docs
+
+TAG="dev"
+
+MY_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+MY_DIR=$(dirname "${MY_PATH}")
+
+# run tests
+docker run --rm \
+  --name ambianic-dev \
+  --mount type=bind,source="$MY_DIR/../",target=/workspace \
+  --net=host \
+  --entrypoint 'bash' \
+  -e CODECOV_TOKEN \
+  ambianic/ambianic-edge:$TAG /workspace/docs/build-docs.sh -u
+

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -1,0 +1,28 @@
+
+# verbose mode, exit on error
+set -ex
+
+# parse command line arguments
+# while getopts ":u" flag
+# do
+#     case "${flag}" in
+#        u) upload_codecov=true;;
+#     esac
+# done
+
+# if [ "$upload_codecov" = true ] ; then
+#     echo 'Code coverage upload flag set. Will upload report to codecov.io'
+# fi
+
+python3 -m pip install -U pdoc3 # python code documentation generator
+BASEDIR=$(dirname $0)
+# Install the ambianic module
+python3 -m pip install -e $BASEDIR/../src
+echo "Script location: ${BASEDIR}"
+# change work dir location to a predictable place
+# where codecov can find the generated reports
+cd $BASEDIR/../
+echo PWD=$PWD
+# python3 -m 
+pdoc --html --output-dir docs/dist src/ambianic
+

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -18,7 +18,6 @@ pip3 install -U pytest # unit test tool
 pip3 install -U codecov # code coverage tool
 pip3 install -U pytest-cov # coverage plugin for pytest
 pip3 install -U pylint # python linter
-pip3 install -U dynaconf
 BASEDIR=$(dirname $0)
 pip3 install -e $BASEDIR/../src
 echo "Script location: ${BASEDIR}"


### PR DESCRIPTION
## Purpose
Generate and publish latest python code docs as part of CI runs

## Approach
Github action that uses pdoc3 to extract docs from python source and build static html files. Then publish to github pages.

## Merge Checklist
- [x]  The code change is tested and works locally.
- [x]  The user and dev documentation is up to date.
