### PR TITLE
feat: enable user friendly device display name

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,8 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
-labels: ''
+title: "[FEATURE] "
+labels: enhancement
 assignees: ''
 
 ---

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run formatting check
         run: |
-          python3 -m pip install -U pylint isort mccabe pre-commit black flake8
+          python3 -m pip install -U pre-commit
           pre-commit install
           pre-commit run --all-files
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -40,3 +40,4 @@ vscode:
   extensions:
     - ms-python.python
     - github.vscode-pull-request-github
+    - eamodio.gitlens

--- a/build/ambianic-docker-entrypoint.sh
+++ b/build/ambianic-docker-entrypoint.sh
@@ -7,10 +7,11 @@ set -ex
 # Which otherwise cause SSL Certificate Verification problems.
 if $(arch | grep -q arm)
 then
-  echo "Re-Installing ca-certifcates on Raspberry Pi / ARM CPU"
   sudo dpkg --configure -a
+  ## update local package info db
+  # sudo apt-get update
+  echo "Re-Installing ca-certifcates on Raspberry Pi / ARM CPU due to unresolved cert validation errors."
   sudo apt-get remove -y ca-certificates
-  sudo apt-get update
   sudo apt-get install -y ca-certificates
 fi
 

--- a/src/ambianic/webapp/fastapi_app.py
+++ b/src/ambianic/webapp/fastapi_app.py
@@ -106,8 +106,9 @@ class StatusResponse(BaseResponse, DeviceInfo):
 def get_status():
     """Returns overall status of the Ambianic Edge device along with
     other device details such as release version."""
+    name = config.get("display_name", "My Ambianic Edge device")
     response_object = StatusResponse(
-        status="OK", version=__version__, display_name="My Ambianic Edge device"
+        status="OK", version=__version__, display_name=name
     )
     return response_object
 
@@ -160,7 +161,7 @@ def get_config():
     return config.as_dict()
 
 
-@app.get("/api/device/display_name")
+@app.get("/api/device/display_name", response_model=str)
 def get_device_display_name():
     """
     Get the user friendly display name for this Ambianic Edge device.
@@ -176,7 +177,7 @@ def get_device_display_name():
 )
 def set_device_display_name(display_name: str):
     """
-    Set the user friendly dispaly name for this Ambianic Edge device.
+    Set a user friendly dispaly name for this Ambianic Edge device.
     """
     if display_name:
         config["display_name"] = display_name

--- a/src/setup.cfg
+++ b/src/setup.cfg
@@ -8,7 +8,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://ambianic.ai
 license = Apache Software License 2.0
-classifiers = 
+classifiers =
 	Development Status :: Beta
 	Programming Language :: Python :: 3
 	OSI Approved :: Apache Software License
@@ -21,4 +21,3 @@ classifiers =
 [options]
 packages = find:
 python_requires = >=3.7
-


### PR DESCRIPTION
## Purpose
This is the edge side implementation for https://github.com/ambianic/ambianic-ui/issues/742

## Approach
Provides REST API `/api/device/display_name/{display_name}` for [setting custom device display name](https://github.com/ivelin/ambianic-edge/blob/d51fe19f132c439b48f175d4ec3241fe23c58577/src/ambianic/webapp/fastapi_app.py#L173). 

Saves custom device name in `config.yaml`.

## Merge Checklist
- [x]  The code change is tested and works locally.
- [x]  There is no commented out code in this PR.
- [x]  No lint errors (use flake8)
- [x]  100% test coverage
