### PR TITLE
feat: added default priority for all events to config file

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -88,6 +88,7 @@ pipelines:
      - detect_falls: # look for falls
         ai_model: fall_detection
         confidence_threshold: 0.6
+        priority: WARNING # default priority for all event detections.
      - save_detections: # save samples from the inference results
         positive_interval: 10
         idle_interval: 600000


### PR DESCRIPTION
This pull request will fix this [issue](https://github.com/ambianic/ambianic-ui/issues/687).

## Purpose
The `WARNING` priority adds a warning level to all detected events allowing them to be captured within the color formatter in the Ambianic PWA timeline.

## Approach
The new code changes within this pull request adds a default priority of `WARNING` level to the `config.yaml` file.

## Merge Checklist
- [x]  The code change is tested and works locally.
- [x]  The user and dev documentation is up to date.
- [x]  There is no commented out code in this PR.
- [x]  No lint errors (use flake8)
- [x]  100% test coverage